### PR TITLE
Fix issue #4

### DIFF
--- a/src/MuTalk-Model/MethodMutation.class.st
+++ b/src/MuTalk-Model/MethodMutation.class.st
@@ -9,7 +9,7 @@ Class {
 		'mutatedNode',
 		'nodeToMutate'
 	],
-	#category : #'MuTalk-Model'
+	#category : 'MuTalk-Model'
 }
 
 { #category : #'instance creation' }

--- a/src/MuTalk-Model/MethodMutation.class.st
+++ b/src/MuTalk-Model/MethodMutation.class.st
@@ -9,7 +9,7 @@ Class {
 		'mutatedNode',
 		'nodeToMutate'
 	],
-	#category : 'MuTalk-Model'
+	#category : #'MuTalk-Model'
 }
 
 { #category : #'instance creation' }
@@ -81,9 +81,19 @@ MethodMutation >> mutatedNode [
 ]
 
 { #category : #accessing }
+MethodMutation >> mutatedNode: aNode [
+	mutatedNode := aNode
+]
+
+{ #category : #accessing }
 MethodMutation >> nodeToMutate [
 	nodeToMutate ifNil: [ self lookupForNodes ].
 	^ nodeToMutate
+]
+
+{ #category : #accessing }
+MethodMutation >> nodeToMutate: aNode [
+	nodeToMutate := aNode
 ]
 
 { #category : #accessing }

--- a/src/MuTalk-Model/MutantOperator.class.st
+++ b/src/MuTalk-Model/MutantOperator.class.st
@@ -1,7 +1,11 @@
 Class {
 	#name : #MutantOperator,
 	#superclass : #Object,
-	#category : 'MuTalk-Model-Operators'
+	#instVars : [
+		'newNode',
+		'oldNode'
+	],
+	#category : #'MuTalk-Model-Operators'
 }
 
 { #category : #accessing }
@@ -69,13 +73,18 @@ MutantOperator >> modifiedSourceFor: aCompiledMethod number: aNumber [
 
 { #category : #private }
 MutantOperator >> modifiedSourceFor: aCompiledMethod with: aParseTree number: aNumber [ 
-	| rewriter parser number |
+	| rewriter parser number nNode |
 	rewriter := RBParseTreeRewriter new.
 	number := aNumber.
 	parser := aParseTree copy.
 	rewriter 
 		replace: self expressionToReplace
-		with: self newExpression
+		withValueFrom: [ :oNode | 
+			nNode := RBParser parseRewriteExpression: self newExpression.
+			nNode := nNode copyInContext: rewriter context.
+			oldNode := oNode.
+			newNode := nNode.
+			newNode ]
 		when: 
 			[ :node | number := number - 1.
 						number = 0 ].
@@ -85,14 +94,18 @@ MutantOperator >> modifiedSourceFor: aCompiledMethod with: aParseTree number: aN
 
 { #category : #private }
 MutantOperator >> mutationFor: aCompiledMethod with: aParseTree number: aNumberOfSelector [ 
-	^ MethodMutation 
+	^ (MethodMutation
 		for: aCompiledMethod
 		using: self
-		result: (self 
+		result:
+		(self
 				modifiedSourceFor: aCompiledMethod
 				with: aParseTree
 				number: aNumberOfSelector)
-		ofClass: aCompiledMethod methodClass
+		ofClass: aCompiledMethod methodClass)
+		nodeToMutate: oldNode;
+		mutatedNode: newNode;
+		yourself
 ]
 
 { #category : #'mutant generation' }

--- a/src/MuTalk-Model/MutantOperator.class.st
+++ b/src/MuTalk-Model/MutantOperator.class.st
@@ -5,7 +5,7 @@ Class {
 		'newNode',
 		'oldNode'
 	],
-	#category : #'MuTalk-Model-Operators'
+	#category : 'MuTalk-Model-Operators'
 }
 
 { #category : #accessing }

--- a/src/MuTalk-TestResources/ClassForTestingCoverage.class.st
+++ b/src/MuTalk-TestResources/ClassForTestingCoverage.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #ClassForTestingCoverage,
 	#superclass : #Object,
-	#category : #'MuTalk-TestResources'
+	#category : 'MuTalk-TestResources'
 }
 
 { #category : #'as yet unclassified' }

--- a/src/MuTalk-TestResources/ClassForTestingCoverage.class.st
+++ b/src/MuTalk-TestResources/ClassForTestingCoverage.class.st
@@ -1,12 +1,20 @@
 Class {
 	#name : #ClassForTestingCoverage,
 	#superclass : #Object,
-	#category : 'MuTalk-TestResources'
+	#category : #'MuTalk-TestResources'
 }
 
 { #category : #'as yet unclassified' }
 ClassForTestingCoverage class >> aClassCoveredMethod [
 	^true.
+]
+
+{ #category : #'instance creation' }
+ClassForTestingCoverage class >> new: aSize [
+	" from UUID class>> #new:"
+	(aSize == 16) ifFalse: [ self error: 'Wrong UUID size' ].
+	
+	^ super new: aSize
 ]
 
 { #category : #'as yet unclassified' }

--- a/src/MuTalk-Tests/MethodMutationTest.class.st
+++ b/src/MuTalk-Tests/MethodMutationTest.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #MethodMutationTest,
 	#superclass : #TestCase,
-	#category : #'MuTalk-Tests'
+	#category : 'MuTalk-Tests'
 }
 
 { #category : #'testing accessing' }

--- a/src/MuTalk-Tests/MethodMutationTest.class.st
+++ b/src/MuTalk-Tests/MethodMutationTest.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #MethodMutationTest,
 	#superclass : #TestCase,
-	#category : 'MuTalk-Tests'
+	#category : #'MuTalk-Tests'
 }
 
 { #category : #'testing accessing' }
@@ -41,4 +41,14 @@ MethodMutationTest >> testAccessingToNodes [
 	self assert: methodMutation nodeToMutate formattedCode = '1 + 2'.
 	self assert: methodMutation mutatedNode formattedCode = '1 - 2'.
 
+]
+
+{ #category : #tests }
+MethodMutationTest >> testMutatedNodeBugFix [
+	| method m |
+	method := ClassForTestingCoverage class>>#new:.
+
+	m := (ReplaceIdentityWithNegationOfIdentity new mutationsFor: method) first.
+	self shouldnt: [ m mutatedNode ] raise:  SubscriptOutOfBounds 
+	
 ]


### PR DESCRIPTION
I extract the old and the new nodes when the mutated sourcecode is generating in `MutantOperator>>#modifiedSourceFor:with:number:`. 

Then, I set these values to `mutatedNode` and `nodeToMutate` variables in `MethodMutation`. 

So, there is no need to call `lookupForNodes` anymore.