### PR TITLE
[improvement] move mutant execution logic to be able to rerun it

### DIFF
--- a/src/MuTalk-Model/MethodMutation.class.st
+++ b/src/MuTalk-Model/MethodMutation.class.st
@@ -7,7 +7,8 @@ Class {
 		'operator',
 		'originalClass',
 		'mutatedNode',
-		'nodeToMutate'
+		'nodeToMutate',
+		'testCaseReferences'
 	],
 	#category : 'MuTalk-Model'
 }

--- a/src/MuTalk-Model/MethodMutation.class.st
+++ b/src/MuTalk-Model/MethodMutation.class.st
@@ -125,6 +125,33 @@ MethodMutation >> printOn: aStream [
 		nextPutAll: originalMethod  selector printString.
 ]
 
+{ #category : #running }
+MethodMutation >> runMutant [
+
+	^ [ 
+		self install.
+		self runTests
+	] ensure: [ self uninstall ]
+]
+
+{ #category : #private }
+MethodMutation >> runTests [
+	| results |
+	results := TestResultCollected new.
+	testCaseReferences collect: [ :tcr | results addAllResults: tcr runUnchecked ].
+	^ results
+]
+
+{ #category : #private }
+MethodMutation >> testCaseReferences [
+	^ testCaseReferences
+]
+
+{ #category : #private }
+MethodMutation >> testCaseReferences: aCollectionOfTestCaseReferences [
+	testCaseReferences := aCollectionOfTestCaseReferences
+]
+
 { #category : #installing }
 MethodMutation >> uninstall [
 	"UnInstall the mutant recompiling the original method into the class."

--- a/src/MuTalk-Model/MethodMutation.class.st
+++ b/src/MuTalk-Model/MethodMutation.class.st
@@ -10,7 +10,7 @@ Class {
 		'nodeToMutate',
 		'testCaseReferences'
 	],
-	#category : 'MuTalk-Model'
+	#category : #'MuTalk-Model'
 }
 
 { #category : #'instance creation' }
@@ -138,7 +138,7 @@ MethodMutation >> runMutant [
 { #category : #private }
 MethodMutation >> runTests [
 	| results |
-	results := TestResultCollected new.
+	results := TestAsserter classForTestResult new.
 	testCaseReferences collect: [ :tcr | results addAllResults: tcr runUnchecked ].
 	^ results
 ]

--- a/src/MuTalk-Model/MutantEvaluation.class.st
+++ b/src/MuTalk-Model/MutantEvaluation.class.st
@@ -86,7 +86,6 @@ MutantEvaluation >> value [
 	self initializeCoverageResultIfNil.
 	mutation testCaseReferences: (strategy testCasesToEvaluate: mutation for: self).
 	testResults := mutation runMutant.
-
 	^ MutantEvaluationResult
 		for: mutation
 		results: testResults

--- a/src/MuTalk-Model/MutantEvaluation.class.st
+++ b/src/MuTalk-Model/MutantEvaluation.class.st
@@ -81,13 +81,12 @@ MutantEvaluation >> testResults [
 { #category : #evaluation }
 MutantEvaluation >> value [
 	| testResults |
-
 	Stdio stdout nextPutAll: mutation originalMethod name asString; lf; flush.
 
 	self initializeCoverageResultIfNil.
-	testResults := [ mutation install.
-	self testResults ]
-		ensure: [ mutation uninstall ].
+	mutation testCaseReferences: (strategy testCasesToEvaluate: mutation for: self).
+	testResults := mutation runMutant.
+
 	^ MutantEvaluationResult
 		for: mutation
 		results: testResults

--- a/src/MuTalk-Model/MutationTestingAnalysis.class.st
+++ b/src/MuTalk-Model/MutationTestingAnalysis.class.st
@@ -260,7 +260,7 @@ MutationTestingAnalysis >> run [
 	methods of
 	those classes) and execute all mutants in the set of testClases.
 	We obtain a result for each mutant generated"
-	^[testCases do: [ :aTestCase | aTestCase run ].
+	^[testCases do: [ :aTestCase | aTestCase runChecked ].
 	logger logAnalysisStartFor:self.
 	elapsedTime := Time millisecondsToRun: [
 					self generateCoverageAnalysis.

--- a/src/MuTalk-Model/TestCaseReference.class.st
+++ b/src/MuTalk-Model/TestCaseReference.class.st
@@ -31,6 +31,19 @@ TestCaseReference >> resources [
 
 { #category : #evaluating }
 TestCaseReference >> run [
+	"kept for retrocompatibility"
+	
+	self deprecated: 'Use #runChecked instead.' transformWith: '`@receiver run' -> '`@receiver runChecked'.
+	^ self runChecked
+]
+
+{ #category : #evaluating }
+TestCaseReference >> run: aTestResult [
+	^self testCase run: aTestResult
+]
+
+{ #category : #evaluating }
+TestCaseReference >> runChecked [
 	| result |
 	"kept for retrocompatibility"
 	^ self runChecked

--- a/src/MuTalk-Model/TestCaseReference.class.st
+++ b/src/MuTalk-Model/TestCaseReference.class.st
@@ -5,7 +5,7 @@ Class {
 		'class',
 		'selector'
 	],
-	#category : 'MuTalk-Model'
+	#category : #'MuTalk-Model'
 }
 
 { #category : #'instance creation' }
@@ -44,14 +44,7 @@ TestCaseReference >> run: aTestResult [
 
 { #category : #evaluating }
 TestCaseReference >> runChecked [
-	| result |
-	"kept for retrocompatibility"
-	^ self runChecked
-]
-
-{ #category : #evaluating }
-TestCaseReference >> runChecked [
-	| result |
+	| result |	
 	result := self testCase run.
 	(result failuresSize > 0 or: [ result errorsSize > 0 ])
 		ifTrue: [ TestsWithErrorsException signalFor: self ].

--- a/src/MuTalk-Model/TestCaseReference.class.st
+++ b/src/MuTalk-Model/TestCaseReference.class.st
@@ -32,15 +32,22 @@ TestCaseReference >> resources [
 { #category : #evaluating }
 TestCaseReference >> run [
 	| result |
+	"kept for retrocompatibility"
+	^ self runChecked
+]
+
+{ #category : #evaluating }
+TestCaseReference >> runChecked [
+	| result |
 	result := self testCase run.
-	(result failuresSize > 0 or: [ result errorsSize > 0])
-		ifTrue: [TestsWithErrorsException signal].
+	(result failuresSize > 0 or: [ result errorsSize > 0 ])
+		ifTrue: [ TestsWithErrorsException signalFor: self ].
 	^ result
 ]
 
 { #category : #evaluating }
-TestCaseReference >> run: aTestResult [
-	^self testCase run: aTestResult
+TestCaseReference >> runUnchecked [
+	^ self testCase run
 ]
 
 { #category : #evaluating }

--- a/src/MuTalk-Model/TestResult.extension.st
+++ b/src/MuTalk-Model/TestResult.extension.st
@@ -1,6 +1,15 @@
 Extension { #name : #TestResult }
 
 { #category : #'*MuTalk-Model' }
+TestResult >> addAllResults: aTestResult [
+
+	failures addAll: aTestResult failures.
+	errors addAll: aTestResult errors.
+	passed addAll: aTestResult passed.
+	skipped addAll: aTestResult skipped.
+]
+
+{ #category : #'*MuTalk-Model' }
 TestResult >> concreteErrors [
     ^ errors
 ]

--- a/src/MuTalk-Tests/MethodInstallerTest.class.st
+++ b/src/MuTalk-Tests/MethodInstallerTest.class.st
@@ -5,7 +5,7 @@ Class {
 		'anonymousClass',
 		'anonymousClassWithMethod'
 	],
-	#category : 'MuTalk-Tests'
+	#category : #'MuTalk-Tests'
 }
 
 { #category : #accessing }
@@ -20,7 +20,7 @@ MethodInstallerTest >> methodInstalled [
 
 ]
 
-{ #category : #'test resources' }
+{ #category : #'as yet unclassified' }
 MethodInstallerTest >> methodToUninstall [ ^self
 ]
 

--- a/src/MuTalk-Tests/MethodMutationTest.class.st
+++ b/src/MuTalk-Tests/MethodMutationTest.class.st
@@ -52,3 +52,23 @@ MethodMutationTest >> testMutatedNodeBugFix [
 	self shouldnt: [ m mutatedNode ] raise:  SubscriptOutOfBounds 
 	
 ]
+
+{ #category : #tests }
+MethodMutationTest >> testMutationRun [
+	| compiledMethod operator modifiedSource methodMutation res |
+	compiledMethod := AuxiliarClassForMutationTestingAnalysis
+		>> #methodWithOnePlusSender.
+	operator := ReplacePlusWithMinusMutantOperator new.
+	modifiedSource := operator
+		modifiedSourceFor: compiledMethod
+		number: 1.
+	methodMutation := MethodMutation
+		for: compiledMethod
+		using: operator
+		result: modifiedSource
+		ofClass: AuxiliarClassForMutationTestingAnalysis.
+	methodMutation testCaseReferences: { TestCaseReference for: #simpleTestCaseRessource in: self class }.
+	res := methodMutation runMutant.
+
+	self assert: res runCount equals: 1.
+]

--- a/src/MuTalk-Tests/MethodMutationTest.class.st
+++ b/src/MuTalk-Tests/MethodMutationTest.class.st
@@ -1,8 +1,13 @@
 Class {
 	#name : #MethodMutationTest,
 	#superclass : #TestCase,
-	#category : 'MuTalk-Tests'
+	#category : #'MuTalk-Tests'
 }
+
+{ #category : #tests }
+MethodMutationTest >> simpleTestCaseRessource [
+	self assert: 1 + 1 equals: 2
+]
 
 { #category : #'testing accessing' }
 MethodMutationTest >> testAccessing [

--- a/src/MuTalk-Tests/TestCaseReferenceTest.class.st
+++ b/src/MuTalk-Tests/TestCaseReferenceTest.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #TestCaseReferenceTest,
 	#superclass : #TestCase,
-	#category : 'MuTalk-Tests'
+	#category : #'MuTalk-Tests'
 }
 
 { #category : #resources }
@@ -13,7 +13,7 @@ TestCaseReferenceTest >> test1 [
 TestCaseReferenceTest >> testATestReferenceResult [
 	| testReference |
 	testReference := self testReferenceForTest1.
-	self assert: testReference run errors isEmpty.
+	self assert: testReference runUnchecked errors isEmpty.
 	
 ]
 


### PR DESCRIPTION
When the process is executed, MethodMutations are created.
It is now also giving it the test cases that need to be executed for this mutation.

This fix also moves the execution logic to MethodMutation, allowing for a mutation to be re executed after the full process has been executed.
This allows for a better post run analysis of the mutant, regardless of if they survived or not.