### PR TITLE
Refactoring baseline

### DIFF
--- a/src/BaselineOfMuTalk/BaselineOfMuTalk.class.st
+++ b/src/BaselineOfMuTalk/BaselineOfMuTalk.class.st
@@ -9,10 +9,6 @@ BaselineOfMuTalk >> baseline: spec [
 	<baseline>
 
 	spec for: #common do: [
-
-		spec for: #'pharo6.x' do: [
-			spec group: 'testCoverage' with: #().].
-
 		spec
 			package: 'TestCoverage';
 			package: 'MuTalk-Model' with: [

--- a/src/BaselineOfMuTalk/BaselineOfMuTalk.class.st
+++ b/src/BaselineOfMuTalk/BaselineOfMuTalk.class.st
@@ -12,18 +12,6 @@ BaselineOfMuTalk >> baseline: spec [
 
 		spec for: #'pharo6.x' do: [
 			spec group: 'testCoverage' with: #().].
-		spec for: #'pharo7.x' do: [
-			spec package: 'TestCoverage'.
-			spec group: 'testCoverage' with: #('TestCoverage').].
-		spec for: #'pharo8.x' do: [
-			spec package: 'TestCoverage'.
-			spec group: 'testCoverage' with: #('TestCoverage').].
-		spec for: #'pharo9.x' do: [
-			spec package: 'TestCoverage'.
-			spec group: 'testCoverage' with: #('TestCoverage').].
-		spec for: #'pharo10.x' do: [
-			spec package: 'TestCoverage'.
-			spec group: 'testCoverage' with: #('TestCoverage').].
 
 		spec
 			package: 'TestCoverage';

--- a/src/BaselineOfMuTalk/BaselineOfMuTalk.class.st
+++ b/src/BaselineOfMuTalk/BaselineOfMuTalk.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #BaselineOfMuTalk,
 	#superclass : #BaselineOf,
-	#category : 'BaselineOfMuTalk'
+	#category : #BaselineOfMuTalk
 }
 
 { #category : #baselines }
@@ -22,9 +22,10 @@ BaselineOfMuTalk >> baseline: spec [
 			spec package: 'TestCoverage'.
 			spec group: 'testCoverage' with: #('TestCoverage').].
 
-		spec 
+		spec
+			package: 'TestCoverage';
 			package: 'MuTalk-Model' with: [
-				spec requires: #('testCoverage')];
+				spec requires: #('TestCoverage')];
 			package: 'MuTalk-TestResources' with: [
 				spec requires: #('MuTalk-Model')];
 			package: 'MuTalk-Tests' with: [


### PR DESCRIPTION
[Question]

As the install for the Pharo versiions 7, 8, 9 and 10 is exactly the same

```st
spec for: #'pharoY.X' do: [
    spec package: 'TestCoverage'.
    spec group: 'testCoverage' with: #('TestCoverage') ]
```

can we remove that and replace it with ?

```st
package: 'TestCoverage';
package: 'MuTalk-Model' with: [ spec requires: #('TestCoverage')];
```