### PR TITLE
Adding inspector extension

### DIFF
--- a/src/BaselineOfMuTalk/BaselineOfMuTalk.class.st
+++ b/src/BaselineOfMuTalk/BaselineOfMuTalk.class.st
@@ -14,6 +14,7 @@ BaselineOfMuTalk >> baseline: spec [
 			spec package: 'MuTalk-Model' with: [ spec includes: #('MuTalk-SpecUI') ].
 			spec package: 'MuTalk-SpecUI' with: [ spec requires: #('MuTalk-Model') ] ].
 		spec for: #'pharo9.x' do: [
+			spec package: 'MuTalk-Model' with: [ spec includes: #('MuTalk-SpecUI') ].
 			spec package: 'MuTalk-SpecUI' with: [ spec requires: #('MuTalk-Model') ] ].
 		
 		spec

--- a/src/BaselineOfMuTalk/BaselineOfMuTalk.class.st
+++ b/src/BaselineOfMuTalk/BaselineOfMuTalk.class.st
@@ -12,7 +12,7 @@ BaselineOfMuTalk >> baseline: spec [
 	
 		spec for: #'pharo10.x' do: [
 			spec package: 'MuTalk-Model' with: [ spec includes: #('MuTalk-SpecUI') ].
-			spec package: 'MuTalk-SpecUI' with: [ spec requires: #('Mutalk-Model') ] ].
+			spec package: 'MuTalk-SpecUI' with: [ spec requires: #('MuTalk-Model') ] ].
 		spec for: #'pharo9.x' do: [
 			spec package: 'MuTalk-SpecUI' with: [ spec requires: #('MuTalk-Model') ] ].
 		

--- a/src/BaselineOfMuTalk/BaselineOfMuTalk.class.st
+++ b/src/BaselineOfMuTalk/BaselineOfMuTalk.class.st
@@ -11,11 +11,9 @@ BaselineOfMuTalk >> baseline: spec [
 	spec for: #common do: [
 	
 		spec for: #'pharo10.x' do: [
-			spec package: 'MuTalk-SpecUI' with: [
-				spec requires: #('MuTalk-Model') ] ].
+			spec package: 'MuTalk-Model' with: [ spec includes: #('MuTalk-SpecUI') ] ].
 		spec for: #'pharo9.x' do: [
-			spec package: 'MuTalk-SpecUI' with: [
-				spec requires: #('MuTalk-Model') ] ].
+			spec package: 'MuTalk-SpecUI' with: [ spec requires: #('MuTalk-Model') ] ].
 		
 		spec
 			package: 'TestCoverage';

--- a/src/BaselineOfMuTalk/BaselineOfMuTalk.class.st
+++ b/src/BaselineOfMuTalk/BaselineOfMuTalk.class.st
@@ -9,6 +9,14 @@ BaselineOfMuTalk >> baseline: spec [
 	<baseline>
 
 	spec for: #common do: [
+	
+		spec for: #'pharo10.x' do: [
+			spec package: 'MuTalk-SpecUI' with: [
+				spec requires: #('MuTalk-Model') ] ].
+		spec for: #'pharo9.x' do: [
+			spec package: 'MuTalk-SpecUI' with: [
+				spec requires: #('MuTalk-Model') ] ].
+		
 		spec
 			package: 'TestCoverage';
 			package: 'MuTalk-Model' with: [

--- a/src/BaselineOfMuTalk/BaselineOfMuTalk.class.st
+++ b/src/BaselineOfMuTalk/BaselineOfMuTalk.class.st
@@ -11,7 +11,8 @@ BaselineOfMuTalk >> baseline: spec [
 	spec for: #common do: [
 	
 		spec for: #'pharo10.x' do: [
-			spec package: 'MuTalk-Model' with: [ spec includes: #('MuTalk-SpecUI') ] ].
+			spec package: 'MuTalk-Model' with: [ spec includes: #('MuTalk-SpecUI') ].
+			spec package: 'MuTalk-SpecUI' with: [ spec requires: #('Mutalk-Model') ] ].
 		spec for: #'pharo9.x' do: [
 			spec package: 'MuTalk-SpecUI' with: [ spec requires: #('MuTalk-Model') ] ].
 		

--- a/src/MuTalk-SpecUI/MutationResultsPresenter.class.st
+++ b/src/MuTalk-SpecUI/MutationResultsPresenter.class.st
@@ -1,0 +1,74 @@
+"
+I am a presenter that show the results of the mutation testing
+"
+Class {
+	#name : #MutationResultsPresenter,
+	#superclass : #SpPresenter,
+	#traits : 'SpTModel',
+	#classTraits : 'SpTModel classTrait',
+	#instVars : [
+		'diffPresenter',
+		'tablePresenter'
+	],
+	#category : #'MuTalk-SpecUI'
+}
+
+{ #category : #accessing }
+MutationResultsPresenter class >> initialExtent [
+
+	^ 800 @ 600
+]
+
+{ #category : #specs }
+MutationResultsPresenter class >> title [
+
+	^ 'Mutation Results'
+]
+
+{ #category : #initialization }
+MutationResultsPresenter >> connectPresenters [
+
+	tablePresenter whenSelectionChangedDo: [ :selection | 
+		| selectedItem |
+		selectedItem := selection selectedItem.
+		diffPresenter
+			leftText: selectedItem mutant originalMethod ast formattedCode;
+			rightText: selectedItem mutant modifiedSource;
+			contextClass: selectedItem mutant originalClass ]
+]
+
+{ #category : #layout }
+MutationResultsPresenter >> defaultLayout [
+
+	^ SpPanedLayout newTopToBottom
+		add: tablePresenter;
+		add: diffPresenter;
+		yourself
+]
+
+{ #category : #initialization }
+MutationResultsPresenter >> initializePresenters [
+
+	tablePresenter := self newTable.
+	tablePresenter
+		items: model;
+		activateOnSingleClick;
+		addColumn: (SpIndexTableColumn new
+			title: '#';
+			beNotExpandable;
+			yourself);
+		addColumn: (SpStringTableColumn
+			title: 'Results'
+			evaluated: [ :each | each printString ]).
+	
+	diffPresenter := self newDiff.
+	diffPresenter showOptions: false
+]
+
+{ #category : #initialization }
+MutationResultsPresenter >> initializeWindow: aWindowPresenter [
+
+	aWindowPresenter
+		title: self class title;
+		initialExtent: self class initialExtent
+]

--- a/src/MuTalk-SpecUI/MutationTestingGeneralResult.extension.st
+++ b/src/MuTalk-SpecUI/MutationTestingGeneralResult.extension.st
@@ -1,0 +1,8 @@
+Extension { #name : #MutationTestingGeneralResult }
+
+{ #category : #'*MuTalk-SpecUI' }
+MutationTestingGeneralResult >> inspectorExtension [
+
+	<inspectorPresentationOrder: 0 title: 'Mutation Results'>
+	^ MutationResultsPresenter on: self aliveMutants
+]

--- a/src/MuTalk-SpecUI/package.st
+++ b/src/MuTalk-SpecUI/package.st
@@ -1,0 +1,1 @@
+Package { #name : #'MuTalk-SpecUI' }


### PR DESCRIPTION
Added presenter for visualising better the results of the test mutation.

If we inspect `analysis generalResult` we will get this inspector:
![Capture d’écran 2022-03-07 à 13 10 49](https://user-images.githubusercontent.com/33934979/157032049-cb7b4be3-af8e-4be4-b0d3-1dfec48d0db6.png)

I also modified the baseline to load the inspector extension only in Pharo 10 and 9. Because for the other Pharo versions Spec2 is not available there.
