### PR TITLE
Optimising mutations to not hold to AST nodes

### DIFF
--- a/src/MuTalk-Model/MethodMutation.class.st
+++ b/src/MuTalk-Model/MethodMutation.class.st
@@ -2,16 +2,25 @@ Class {
 	#name : #MethodMutation,
 	#superclass : #Object,
 	#instVars : [
+		'nodeNumber',
 		'originalMethod',
 		'modifiedSource',
 		'operator',
 		'originalClass',
-		'mutatedNode',
-		'nodeToMutate',
 		'testCaseReferences'
 	],
 	#category : #'MuTalk-Model'
 }
+
+{ #category : #'instance creation' }
+MethodMutation class >> for: aMethod using: anOperatorApplied nodeNumber: aNodeNumber ofClass: aClass [
+	^ self new
+		initializeFor: aMethod
+		using: anOperatorApplied
+		nodeNumber: aNodeNumber
+		ofClass: aClass;
+		 yourself
+]
 
 { #category : #'instance creation' }
 MethodMutation class >> for: aMethod using: anOperatorApplied result: aModifiedSource ofClass: aClass [
@@ -21,6 +30,14 @@ MethodMutation class >> for: aMethod using: anOperatorApplied result: aModifiedS
 		result: aModifiedSource
 		ofClass: aClass;
 		 yourself
+]
+
+{ #category : #'initialize-release' }
+MethodMutation >> initializeFor: aMethod using: anOperatorApplied nodeNumber: aNodeNumber ofClass: aClass [
+	originalMethod := aMethod.
+	operator := anOperatorApplied.
+	nodeNumber := aNodeNumber.
+	originalClass := aClass
 ]
 
 { #category : #'initialize-release' }
@@ -37,39 +54,6 @@ MethodMutation >> install [
 	MethodInstaller new installFromSource: modifiedSource in: originalClass
 ]
 
-{ #category : #private }
-MethodMutation >> lookUpForNodesFromChildrenOfMutated: aPossibleMutatedRBMethodNode comparingWithChildrenOfOriginal: anOriginalRBMethodNode [ 
-	| childrenOfMutatedMethod childrenOfOriginalMethod |
-	childrenOfMutatedMethod := aPossibleMutatedRBMethodNode children.
-	childrenOfOriginalMethod := anOriginalRBMethodNode children.
-	1 to: childrenOfMutatedMethod size do: 
-		[ :childNumber | 
-			self lookUpForNodesFromMutated:  (childrenOfMutatedMethod at: childNumber)
-				  comparingWithOriginal: (childrenOfOriginalMethod at: childNumber).
-			mutatedNode ifNotNil: [^self]]
-
-	
-]
-
-{ #category : #private }
-MethodMutation >> lookUpForNodesFromMutated: aPossibleMutatedRBMethodNode comparingWithOriginal: anOriginalRBMethodNode [ 
-	(self operator 
-		isNodeOfMutation: aPossibleMutatedRBMethodNode
-		comparingWith: anOriginalRBMethodNode) ifTrue: 
-		[ nodeToMutate := anOriginalRBMethodNode.
-		mutatedNode := aPossibleMutatedRBMethodNode ].
-	aPossibleMutatedRBMethodNode children isEmpty ifTrue: [ ^ nil ].
-	^ self 
-		lookUpForNodesFromChildrenOfMutated: aPossibleMutatedRBMethodNode
-		comparingWithChildrenOfOriginal: anOriginalRBMethodNode
-]
-
-{ #category : #private }
-MethodMutation >> lookupForNodes [
-	self lookUpForNodesFromMutated: (RBParser parseMethod: self modifiedSource)
-		  comparingWithOriginal: (RBParser parseMethod: self originalSource ).
-]
-
 { #category : #accessing }
 MethodMutation >> modifiedSource [
 	^ modifiedSource
@@ -77,24 +61,28 @@ MethodMutation >> modifiedSource [
 
 { #category : #accessing }
 MethodMutation >> mutatedNode [
-	mutatedNode ifNil:[self lookupForNodes ].
-	^mutatedNode. 
+
+	^ operator applyTo: self nodeToMutate
 ]
 
 { #category : #accessing }
-MethodMutation >> mutatedNode: aNode [
-	mutatedNode := aNode
+MethodMutation >> nodeNumber: anInteger [ 
+	nodeNumber := anInteger
 ]
 
 { #category : #accessing }
 MethodMutation >> nodeToMutate [
-	nodeToMutate ifNil: [ self lookupForNodes ].
-	^ nodeToMutate
-]
 
-{ #category : #accessing }
-MethodMutation >> nodeToMutate: aNode [
-	nodeToMutate := aNode
+	| n searcher |
+	n := 1.
+	searcher := RBParseTreeSearcher new
+		            matches: operator expressionToReplace
+		            do: [ :node :answer | 
+			            n = nodeNumber ifTrue: [ ^ node ].
+			            n := n + 1 ];
+		            yourself.
+	searcher executeTree: originalMethod ast.
+	self error: 'Not found'
 ]
 
 { #category : #accessing }

--- a/src/MuTalk-Model/MutantOperator.class.st
+++ b/src/MuTalk-Model/MutantOperator.class.st
@@ -75,6 +75,20 @@ MutantOperator class >> recursionsDetectionThreshold [
 	^ 1024
 ]
 
+{ #category : #applying }
+MutantOperator >> applyTo: anOldNode [
+
+	| rewriter aNewNode |
+	rewriter := RBParseTreeRewriter new.
+	rewriter
+		replace: self expressionToReplace 
+		withValueFrom: [ :oNode |
+			aNewNode := RBParser parseRewriteExpression: self newExpression.
+			aNewNode := aNewNode copyInContext: rewriter context ].
+	rewriter executeTree: anOldNode copy.
+	^ aNewNode
+]
+
 { #category : #printing }
 MutantOperator >> description [
 	self subclassResponsibility
@@ -167,19 +181,18 @@ MutantOperator >> modifyForRecursionDetection: aBoolean [
 ]
 
 { #category : #private }
-MutantOperator >> mutationFor: aCompiledMethod with: aParseTree number: aNumberOfSelector [ 
+MutantOperator >> mutationFor: aCompiledMethod with: aParseTree number: aNumberOfSelector [
+
 	^ (MethodMutation
-		for: aCompiledMethod
-		using: self
-		result:
-		(self
-				modifiedSourceFor: aCompiledMethod
-				with: aParseTree
-				number: aNumberOfSelector)
-		ofClass: aCompiledMethod methodClass)
-		nodeToMutate: oldNode;
-		mutatedNode: newNode;
-		yourself
+		   for: aCompiledMethod
+		   using: self
+		   result: (self
+				    modifiedSourceFor: aCompiledMethod
+				    with: aParseTree
+				    number: aNumberOfSelector)
+		   ofClass: aCompiledMethod methodClass)
+		  nodeNumber: aNumberOfSelector;
+		  yourself
 ]
 
 { #category : #'mutant generation' }

--- a/src/MuTalk-Tests/MethodMutationTest.class.st
+++ b/src/MuTalk-Tests/MethodMutationTest.class.st
@@ -40,7 +40,7 @@ MethodMutationTest >> testAccessingToNodes [
 	methodMutation := MethodMutation 
 		for: compiledMethod 
 		using: operator 
-		result: modifiedSource 
+		nodeNumber: 1
 		ofClass: AuxiliarClassForMutationTestingAnalysis.
 		
 	self assert: methodMutation nodeToMutate formattedCode = '1 + 2'.

--- a/src/MuTalk-Tests/MutantKillingSuggesionTest.class.st
+++ b/src/MuTalk-Tests/MutantKillingSuggesionTest.class.st
@@ -4,7 +4,7 @@ Class {
 	#instVars : [
 		'resource'
 	],
-	#category : 'MuTalk-Tests'
+	#category : #'MuTalk-Tests'
 }
 
 { #category : #accessing }
@@ -126,7 +126,7 @@ MutantKillingSuggesionTest >> testSuggestionToKillRemoveCaret [
 	| operator mutation |
 	operator := RemoveCaretOperator new.
 	mutation := (operator mutationsFor: self class >> #methodToTestSuggestionToKillRCOWithAssignments) first.
-	self assert: (MutantKillingSuggestionGenerator new suggestionFor: mutation) = 'It is missing a test case to check that the method is returning aValue + anotherValue'
+	self assert: (MutantKillingSuggestionGenerator new suggestionFor: mutation) equals: 'It is missing a test case to check that the method is returning aValue + anotherValue'
 ]
 
 { #category : #testing }


### PR DESCRIPTION
AST nodes are only held for testing purposes but are not used in the model.
These changes make that AST nodes are computed on demand instead of cached.

This makes that mid-sized analyses take less than half of the space.
In the example below, memory consumption (measured using https://github.com/tesonep/spaceAndTime) went down from 120MB to 50MB roughly.
Still, we need to remove the cached source code that takes also some space, it will come tomorrow.

Without these optimisations, it seems unfeasible for large programs with tons of mutations.

```smalltalk
testCases :=  { VMJittedPrimitiveAtPutTest  }.
classesToMutate := { 
	CogARMv8Compiler }.

analysis := MutationTestingAnalysis
    testCasesFrom: testCases
    mutating: classesToMutate
    using: MutantOperator contents
	with: SelectingFromCoverageMutantEvaluationStrategy new
    with: SelectingFromCoverageMutationsGenerationStrategy new.

analysis run.

stats := GraphSpaceStatistics new
	rootObject: analysis;
	ignoreReferencesToClasses;
	ignore: Smalltalk;
	yourself.

stats totalSizeInBytes.
"
before: 122 755 048
after:  50 102 312"
```