### PR TITLE
Create a matrix and heatmap from existing MTAnalysis

### DIFF
--- a/src/MuTalk-Model/MTAnalysis.class.st
+++ b/src/MuTalk-Model/MTAnalysis.class.st
@@ -208,7 +208,7 @@ MTAnalysis >> logger: anObject [
 	logger := anObject
 ]
 
-{ #category : 'as yet unclassified' }
+{ #category : 'accessing' }
 MTAnalysis >> methodSize [
 
 	^ (self modelClasses flatCollect: #methods) size

--- a/src/MuTalk-Utilities/MTAnalysis.extension.st
+++ b/src/MuTalk-Utilities/MTAnalysis.extension.st
@@ -1,6 +1,14 @@
 Extension { #name : 'MTAnalysis' }
 
 { #category : '*MuTalk-Utilities' }
+MTAnalysis >> generateHeatmap [
+
+	| matrix |
+	matrix := MTMatrix new analysis: self.
+	matrix generateHeatmap
+]
+
+{ #category : '*MuTalk-Utilities' }
 MTAnalysis >> generateMatrix [
 
 	| matrix |

--- a/src/MuTalk-Utilities/MTMatrix.class.st
+++ b/src/MuTalk-Utilities/MTMatrix.class.st
@@ -80,6 +80,8 @@ MTMatrix >> analysis [
 MTMatrix >> analysis: anAnalysis [
 
 	analysis := anAnalysis.
+	testClasses := (anAnalysis testCases groupedBy: [ :testCase |
+		                testCase testCaseClass ]) keys.
 	testCases := analysis testCases.
 	mutations := analysis mutations.
 	self fillMatrix


### PR DESCRIPTION
Fixes #122 
Added ability to generate a matrix and a heatmap from an existing analysis that has already been run. It can be done from the class `MTMatrix` or directly from `MTAnalysis` with extension methods.