### PR TITLE
Skip CI test for Pharo 9

### DIFF
--- a/src/MuTalk-CI-Tests/MTCIMarkdownExporterTest.class.st
+++ b/src/MuTalk-CI-Tests/MTCIMarkdownExporterTest.class.st
@@ -9,6 +9,8 @@ Class {
 MTCIMarkdownExporterTest >> testMarkdownExporter [
 
 	| analysis md moreInfo |
+	(SystemVersion current version beginsWith: 'Pharo9') ifTrue: [ 
+		^ self skip ]. "Microdown is not available in Pharo 9"
 	analysis := MTAnalysis new
 		            testClasses: { MTSmallBankTest };
 		            classesToMutate: { MTSmallBank }.


### PR DESCRIPTION
Fixes #119
This test uses Microdown, which is not available in Pharo 9.