### PR TITLE
Sortable columns for analysis result

### DIFF
--- a/src/MuTalk-SpecUI/MTMutationResultsPresenter.class.st
+++ b/src/MuTalk-SpecUI/MTMutationResultsPresenter.class.st
@@ -29,13 +29,14 @@ MTMutationResultsPresenter class >> title [
 { #category : 'initialization' }
 MTMutationResultsPresenter >> connectPresenters [
 
-	tablePresenter whenSelectionChangedDo: [ :selection | 
-		| selectedItem |
-		selectedItem := selection selectedItem.
-		diffPresenter
-			leftText: selectedItem mutant originalMethod ast formattedCode;
-			rightText: selectedItem mutant modifiedSource;
-			contextClass: selectedItem mutant originalClass ]
+	tablePresenter whenSelectionChangedDo: [ :selection |
+			| selectedItem |
+			selectedItem := selection selectedItem.
+			selectedItem ifNotNil: [
+					diffPresenter
+						leftText: selectedItem mutant originalMethod ast formattedCode;
+						rightText: selectedItem mutant modifiedSource;
+						contextClass: selectedItem mutant originalClass ] ]
 ]
 
 { #category : 'layout' }
@@ -55,13 +56,22 @@ MTMutationResultsPresenter >> initializePresenters [
 		items: model;
 		activateOnSingleClick;
 		addColumn: (SpIndexTableColumn new
-			title: '#';
-			beNotExpandable;
-			yourself);
-		addColumn: (SpStringTableColumn
-			title: 'Results'
-			evaluated: [ :each | each printString ]).
-	
+				 title: '#';
+				 beNotExpandable;
+				 yourself);
+		addColumn: (SpStringTableColumn new
+				 title: 'Mutant operator';
+				 evaluated: [ :each | each mutant operator description ];
+				 beSortable);
+		addColumn: (SpStringTableColumn new
+				 title: 'Class';
+				 evaluated: [ :each | each mutant originalClass ];
+				 beSortable);
+		addColumn: (SpStringTableColumn new
+				 title: 'Method';
+				 evaluated: [ :each | each mutant originalMethod printString ];
+				 beSortable).
+
 	diffPresenter := self newDiff.
 	diffPresenter showOptions: false
 ]

--- a/src/MuTalk-SpecUI/MTMutationResultsPresenter.class.st
+++ b/src/MuTalk-SpecUI/MTMutationResultsPresenter.class.st
@@ -64,10 +64,6 @@ MTMutationResultsPresenter >> initializePresenters [
 				 evaluated: [ :each | each mutant operator description ];
 				 beSortable);
 		addColumn: (SpStringTableColumn new
-				 title: 'Class';
-				 evaluated: [ :each | each mutant originalClass ];
-				 beSortable);
-		addColumn: (SpStringTableColumn new
 				 title: 'Method';
 				 evaluated: [ :each | each mutant originalMethod printString ];
 				 beSortable).


### PR DESCRIPTION
Fixes #136 

Added sortable columns in the inspector of the analysis result. It can be sorted by mutant operator or by method (Class>>#method). It looks like this:
<img width="809" height="676" alt="image" src="https://github.com/user-attachments/assets/8eb4c1f1-0fbd-4981-bb57-d58e80a3b372" />
